### PR TITLE
Improves readability and compatibility with outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ Indirectly based on a school project from a grade 12 CS class.
 
 The `__name__ == "__main__"` is in `svg_to_desmos.py`.
 
+### How to use it
+
+ - Put the path to your svg file at the bottom of `svg_to_desmos.py` or at the top of the main function in `main.py`, then run the python.
+ - Go to [Desmos](https://www.desmos.com/calculator).
+ - Open the browser console (on chrome you right click and hit inspect element), and paste in the contents of desmos.js OR
+ - Go to desmos.txt and paste the expressions in one by one if you dont have access to the console (on school computers for example). Make sure to manually adjust the settings and apply the colors, as this option wont do it automatically.
+
 ## Gallery
 
 [A hermit crab I created for a school project in my grade 10 year](https://www.desmos.com/calculator/cjs9zhmfdq) - 16,978 bytes • 32 expressions

--- a/main.py
+++ b/main.py
@@ -34,9 +34,10 @@ def main():
     expressions_app = merge_shapes.extract_common_latex(shapes)
     print(len(expressions_app), "common expressions extracted.")
     expressions = svg_to_desmos.shapes_to_desmos(shapes, expressions_app)
+    open('desmos.txt', 'w').write(svg_to_desmos.expressions_to_txt(expressions))
     expressions = json.dumps(expressions, separators=(',', ':'))
     expressions = f"var s=Calc.getState();s['expressions']['list']={expressions};Calc.setState(s);"
-    open(".desmos", 'w').write(expressions)
+    open("desmos.js", 'w').write(expressions)
     print(len(expressions), "bytes")
 
 


### PR DESCRIPTION
I found your repo and thought it was cool, but the js outputs to only one line, and i cant run it with inspect element from the school computers, so i made the js more readable by adding newlines and indentations, i gave it the .js extention to make it obvious what its supposed to do. i also added a txt file that outputs the raw latex so you can paste it into desmos manually instead of with inspect. i also added some instructions to the readme file. thought these were helpful changes but you dont have to pull.